### PR TITLE
Adding require 'rubygems' for supporting ruby 1.8 and newer.

### DIFF
--- a/puppetdb_command_discarded
+++ b/puppetdb_command_discarded
@@ -15,6 +15,7 @@ when 'config'
   puts 'commands.type COUNTER'
 when 'fetch'
   require 'net/http'
+  require 'rubygems'
   require 'json'
 
   http = Net::HTTP.new('localhost', 8080)

--- a/puppetdb_command_fatal
+++ b/puppetdb_command_fatal
@@ -15,6 +15,7 @@ when 'config'
   puts 'commands.type COUNTER'
 when 'fetch'
   require 'net/http'
+  require 'rubygems'
   require 'json'
 
   http = Net::HTTP.new('localhost', 8080)

--- a/puppetdb_command_processed
+++ b/puppetdb_command_processed
@@ -15,6 +15,7 @@ when 'config'
   puts 'commands.type COUNTER'
 when 'fetch'
   require 'net/http'
+  require 'rubygems'
   require 'json'
 
   http = Net::HTTP.new('localhost', 8080)

--- a/puppetdb_command_processing_rate
+++ b/puppetdb_command_processing_rate
@@ -15,6 +15,7 @@ when 'config'
   puts 'rate.type GAUGE'
 when 'fetch'
   require 'net/http'
+  require 'rubygems'
   require 'json'
 
   http = Net::HTTP.new('localhost', 8080)

--- a/puppetdb_command_processing_time
+++ b/puppetdb_command_processing_time
@@ -29,6 +29,7 @@ when 'config'
   puts '999.type GAUGE'
 when 'fetch'
   require 'net/http'
+  require 'rubygems'
   require 'json'
 
   http = Net::HTTP.new('localhost', 8080)

--- a/puppetdb_command_retried
+++ b/puppetdb_command_retried
@@ -15,6 +15,7 @@ when 'config'
   puts 'commands.type COUNTER'
 when 'fetch'
   require 'net/http'
+  require 'rubygems'
   require 'json'
 
   http = Net::HTTP.new('localhost', 8080)

--- a/puppetdb_database
+++ b/puppetdb_database
@@ -19,6 +19,7 @@ when 'config'
   puts 'statementexecution.type COUNTER'
 when 'fetch'
   require 'net/http'
+  require 'rubygems'
   require 'json'
 
   http = Net::HTTP.new('localhost', 8080)

--- a/puppetdb_jvm_memory
+++ b/puppetdb_jvm_memory
@@ -28,6 +28,7 @@ when 'config'
   puts 'nonheapcommitted.type GAUGE'
 when 'fetch'
   require 'net/http'
+  require 'rubygems'
   require 'json'
 
   http = Net::HTTP.new('localhost', 8080)

--- a/puppetdb_queue_depth
+++ b/puppetdb_queue_depth
@@ -15,6 +15,7 @@ when 'config'
   puts 'depth.type GAUGE'
 when 'fetch'
   require 'net/http'
+  require 'rubygems'
   require 'json'
 
   http = Net::HTTP.new('localhost', 8080)


### PR DESCRIPTION
Ruby 1.8+ doesn't automatically include rubygems.

http://stackoverflow.com/questions/14994468/ruby-cant-load-json-gem
